### PR TITLE
feature:add tray menu and go to application button

### DIFF
--- a/package.json
+++ b/package.json
@@ -43,6 +43,14 @@
       "icon": "./public/images/icon.icns"
     }
   },
+  "protocols": [
+    {
+      "name": "Electron Fiddle",
+      "schemes": [
+        "electron-fiddle"
+      ]
+    }
+  ],
   "eslintConfig": {
     "extends": "react-app"
   },

--- a/public/electron.js
+++ b/public/electron.js
@@ -1,5 +1,7 @@
 const { default: axios } = require('axios');
 const { app, BrowserWindow, Menu, Tray } = require('electron');
+const { shell } = require('electron/common');
+const { dialog } = require('electron/main');
 const path = require('path');
 
 app.commandLine.appendSwitch(
@@ -16,6 +18,12 @@ app.whenReady().then(() => {
   tray = new Tray(path.join(__dirname, '/images/note.png'));
 
   const contextMenu = Menu.buildFromTemplate([
+    {
+      label: 'Melory',
+      click: () => {
+        shell.openExternal('https://gracious-euclid-c4ba43.netlify.app/');
+      },
+    },
     {
       label: '재생',
       click: async () => {
@@ -78,7 +86,6 @@ app.whenReady().then(() => {
       submenu: [
         {
           label: 'Happy',
-          type: 'radio',
           click: async () => {
             const device = await axios.get(
               `https://api.spotify.com/v1/me/player/devices`,
@@ -122,7 +129,6 @@ app.whenReady().then(() => {
         },
         {
           label: 'Sad',
-          type: 'radio',
           click: async () => {
             const device = await axios.get(
               `https://api.spotify.com/v1/me/player/devices`,
@@ -166,7 +172,6 @@ app.whenReady().then(() => {
         },
         {
           label: 'Mood',
-          type: 'radio',
           click: async () => {
             const device = await axios.get(
               `https://api.spotify.com/v1/me/player/devices`,
@@ -224,7 +229,7 @@ app.whenReady().then(() => {
 
 function createWindow() {
   const mainWindow = new BrowserWindow({
-    width: 1000,
+    width: 900,
     height: 700,
     icon: path.join(__dirname, '/iamges/icon.icns'),
     webPreferences: {
@@ -241,6 +246,16 @@ function createWindow() {
     });
 
   mainWindow.loadURL('https://gracious-euclid-c4ba43.netlify.app/');
+
+  if (process.defaultApp) {
+    if (process.argv.length >= 2) {
+      app.setAsDefaultProtocolClient('electron-fiddle', process.execPath, [
+        path.resolve(process.argv[1]),
+      ]);
+    }
+  } else {
+    app.setAsDefaultProtocolClient('electron-fiddle');
+  }
 }
 
 app.whenReady().then(() => {
@@ -262,3 +277,7 @@ app.on(
     callback(true);
   },
 );
+
+app.on('open-url', (event, url) => {
+  dialog.showErrorBox('Welcome Back', `You arrived from: ${url}`);
+});

--- a/src/components/Header/Header.js
+++ b/src/components/Header/Header.js
@@ -52,7 +52,8 @@ const Menu = styled.div`
   font-family: 'Archivo Black', sans-serif;
   animation: ${openMenu} 0.4s ease;
 
-  div {
+  div,
+  a {
     font-size: 50px;
     margin: 12px 0;
     cursor: pointer;
@@ -140,6 +141,7 @@ export const Header = () => {
           >
             Visualization
           </div>
+          <a href="electron-fiddle://open">APPLICATION</a>
           <div
             onClick={() => {
               window.localStorage.clear();


### PR DESCRIPTION
# Electron


## 카드에서 구현 혹은 해결하려는 내용

- 웹 페이지 메뉴에서 어플리케이션 메뉴를 누르면 바로 앱이 실행된다(설치되었다는 가정하에)
- 앱 상태바에서 melory 메뉴를 클릭하면 웹페이지가 열린다.

